### PR TITLE
Add support for Date/Time field filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 zip_build/
+__pycache__/

--- a/data_layer_range_filter_widget.py
+++ b/data_layer_range_filter_widget.py
@@ -4,7 +4,7 @@
 # which evolved from this code:
 #   code from https://github.com/qgis/QGIS/pull/3170
 #
-# This is a work in progress. There are many things still to improve. 
+# This is a work in progress. There are many things still to improve.
 # TODO: save settings
 # vlayer.setCustomProperty("mytext", "hello world")
 # read the value again (returning "default text" if not found)
@@ -17,6 +17,7 @@ from qgis.PyQt.QtWidgets import *
 from qgis.PyQt import QtCore
 from qgis.core import QgsMessageLog, QgsAggregateCalculator, Qgis
 from qgis.core import QgsMapLayer, QgsExpression, QgsExpressionContext, QgsExpressionContextUtils
+from qgis.PyQt.QtCore import QDate, QDateTime
 from qgis.gui import QgsLayerTreeEmbeddedWidgetProvider, QgsLayerTreeEmbeddedWidgetRegistry
 from .qrangeslider import QRangeSlider
 
@@ -24,9 +25,10 @@ import numbers
 import math
 
 class RangeSlider(QWidget):
-    def __init__(self, parent, field_name, fmin, fmax):
+    def __init__(self, parent, field_name, fmin, fmax, is_date_or_time=False):
         if not isinstance(fmin, numbers.Number) or not isinstance(fmax, numbers.Number):
-          raise ValueError("Min or Max is not a number") 
+          raise ValueError("Min or Max is not a number")
+        self.is_date_or_time = is_date_or_time
         QWidget.__init__(self)
         self.parent = parent
         self.field_name = field_name
@@ -38,12 +40,12 @@ class RangeSlider(QWidget):
         self.slider.setFixedHeight(16)
         self.slider.startValueChanged.connect(self.on_value_changed)
         self.slider.endValueChanged.connect(self.on_value_changed)
-        
-        QgsMessageLog.logMessage("Creating Range Slider for field %s" % self.field_name, 'Range Filter Plugin', level=Qgis.Info)        
-        
-        
+
+        QgsMessageLog.logMessage("Creating Range Slider for field %s" % self.field_name, 'Range Filter Plugin', level=Qgis.Info)
+
+
         #self.on_value_changed()
-        
+
         layout = QHBoxLayout()
         label = QLabel(field_name)
         label.setToolTip(field_name)
@@ -52,57 +54,107 @@ class RangeSlider(QWidget):
         layout.addWidget(self.slider)
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
-        
+
         self.installEventFilter(self)
-    
+
     def pretty(self, slider_num):
         num = (float(slider_num)/self.slider.max()) * (self.fmax - self.fmin) + self.fmin
         # handle edge case where the max and the min are the same
         if self.fmax == self.fmin:
           # disable slider movement if there's no range
           self.slider.setEnabled(False)
+          if self.is_date_or_time:
+             return QDateTime.fromMSecsSinceEpoch(int(self.fmax * 1000)).toString("yyyy-MM-dd HH:mm:ss")
           if self.fmax > 10:
             return str(int(self.fmax))
           else:
             return '{0:.2f}'.format(self.fmax)
-        
+
         pretty_out = ""
-        
+
         # handle corner case where we're looking at the maximum number, and need to make sure the filter value is above that
         if num == self.fmax:
-          if self.fmax - self.fmin > 10:
+          if self.is_date_or_time:
+            pass # exact max
+          elif self.fmax - self.fmin > 10:
             pretty_out = str(math.ceil(num))
           else:
             num += 0.01
-            pretty_out = '{0:.2f}'.format(num)          
+            pretty_out = '{0:.2f}'.format(num)
+        elif self.is_date_or_time:
+            pass # handle below
         elif self.fmax - self.fmin > 10:
             pretty_out = str(int(num))
         else:
             pretty_out = '{0:.2f}'.format(num)
-        
-        #QgsMessageLog.logMessage("Slider Value: %f, Converted num: %s" % (slider_num, pretty_out), 'Range Filter Plugin', level=Qgis.Info)        
-        
+
+        if self.is_date_or_time:
+            dt = QDateTime.fromMSecsSinceEpoch(int(num * 1000))
+            diff = self.fmax - self.fmin
+            if diff < 86400:
+                pretty_out = dt.toString("HH:mm:ss")
+            elif diff < 2592000:
+                pretty_out = dt.toString("yyyy-MM-dd HH:mm")
+            else:
+                pretty_out = dt.toString("yyyy-MM-dd")
+
+        #QgsMessageLog.logMessage("Slider Value: %f, Converted num: %s" % (slider_num, pretty_out), 'Range Filter Plugin', level=Qgis.Info)
+
         return pretty_out
-        
-    
+
+    def getQueryValue(self, slider_num):
+        num = (float(slider_num)/self.slider.max()) * (self.fmax - self.fmin) + self.fmin
+
+        if self.is_date_or_time:
+            dt = QDateTime.fromMSecsSinceEpoch(int(num * 1000))
+            return "'" + dt.toString("yyyy-MM-dd HH:mm:ss") + "'"
+
+        if self.fmax == self.fmin:
+            return str(self.fmax)
+
+        if num == self.fmax:
+          if self.fmax - self.fmin > 10:
+            return str(math.ceil(num))
+          else:
+            num += 0.01
+            return str(num)
+        elif self.fmax - self.fmin > 10:
+            return str(int(num))
+        else:
+            return str(num)
+
+
     def eventFilter(self, source, event):
         # handle right click removal of features to filter
         if (event.type() == QtCore.QEvent.ContextMenu and
             source is self):
             menu = QMenu()
-            menu.addAction('Remove %s' % self.field_name)
-            if menu.exec_(event.globalPos()):
+
+            coerce_action_text = 'Treat as Number' if self.is_date_or_time else 'Treat as Date/Time'
+            action_coerce = menu.addAction(coerce_action_text)
+            action_remove = menu.addAction('Remove %s' % self.field_name)
+
+            selected_action = menu.exec_(event.globalPos())
+            if selected_action == action_remove:
                 item = source.parent.on_remove_slider(self)
+            elif selected_action == action_coerce:
+                self.is_date_or_time = not self.is_date_or_time
+                self.slider.update()
+                self.slider.repaint()
+                # store settings
+                source.parent.on_coerce_slider(self)
+                self.on_value_changed() # re-trigger filter query with new formatting
+
             return True
         return False #super(DataRangeSliders, self).eventFilter(source, event)
 
     def _getStartEndValuesStr(self):
-        return (self.pretty(self.slider.start()), self.pretty(self.slider.end()))
-        
+        return (self.getQueryValue(self.slider.start()), self.getQueryValue(self.slider.end()))
+
     def getRangeFilter(self):
         if self._dirty == False:
           return ""
-        
+
         (start_actual_val, end_actual_val) = self._getStartEndValuesStr()
         filter_clause1 = '"%s" >= %s' % (self.field_name, start_actual_val)
         filter_clause2 = '"%s" <= %s' % (self.field_name, end_actual_val)
@@ -111,29 +163,29 @@ class RangeSlider(QWidget):
 
     def on_value_changed(self):
         if self._dirty == False:
-          QgsMessageLog.logMessage("Switching field %s to dirty" % self.field_name, 'Range Filter Plugin', level=Qgis.Info)        
+          QgsMessageLog.logMessage("Switching field %s to dirty" % self.field_name, 'Range Filter Plugin', level=Qgis.Info)
           self._dirty = True
         self.parent.on_slider_changed(self)
-        
+
 SLIDER_LIST_CONFIG_NAME = "!!SLIDERS!!"
 class DataLayerRangeFilterWidget(QWidget):
 
     def __init__(self, layer):
         QWidget.__init__(self)
-        #QgsMessageLog.logMessage("Widget Loaded", 'Range Filter Plugin', level=Qgis.Info)        
-        
+        #QgsMessageLog.logMessage("Widget Loaded", 'Range Filter Plugin', level=Qgis.Info)
+
         layout = QVBoxLayout()
         self.setLayout(layout)
         self.layer = layer
         self.sliders = []
         self.layout = layout
-        
+
         db = self.layer.dataProvider()
         # TURN OFF ALL FILTERING prior to analyzing the data
         # TODO: take whatever filter already exists on the data now and make sure those are
-        # honoured. 
+        # honoured.
         db.setSubsetString("")
-     
+
         slider_names = self.layer.customProperty(WIDGET_SETTING_PREFIX % SLIDER_LIST_CONFIG_NAME, None)
         if slider_names is not None:
             slider_names = slider_names.split("###")
@@ -141,54 +193,106 @@ class DataLayerRangeFilterWidget(QWidget):
                 self._add_slider(name)
         else:
             for field in db.fields():
-                QgsMessageLog.logMessage("Adding slider for field %s" % field.name(), 'Range Filter Plugin', level=Qgis.Warning)        
+                QgsMessageLog.logMessage("Adding slider for field %s" % field.name(), 'Range Filter Plugin', level=Qgis.Warning)
                 self._add_slider(field.name())
-        QgsMessageLog.logMessage("DONE adding sliders", 'Range Filter Plugin', level=Qgis.Warning)        
+        QgsMessageLog.logMessage("DONE adding sliders", 'Range Filter Plugin', level=Qgis.Warning)
         self._save_sliders()
-        
+
         # cleanup handling
         self.layer.willBeDeleted.connect(self.onLayerRemoved)
         self.installEventFilter(self)
-    
+
     def onLayerRemoved(self):
       self.layer = None
-    
+
     def eventFilter(self, source, event):
       # TODO: This event is emitted when the legend widget is removed. I am not sure if this is the right way to handle widget removeal
-      # with QGIS. Requires asking around and looking at some examples and docs, which weren't easy to find alas. 
+      # with QGIS. Requires asking around and looking at some examples and docs, which weren't easy to find alas.
       if self.layer and event.type() == QtCore.QEvent.DeferredDelete:
-        #QgsMessageLog.logMessage("Event %d" % event.type(), 'Range Filter Plugin', level=Qgis.Warning)        
+        #QgsMessageLog.logMessage("Event %d" % event.type(), 'Range Filter Plugin', level=Qgis.Warning)
         db = self.layer.dataProvider()
         db.setSubsetString("")
-      return False  
-    
+      return False
+
     def _save_sliders(self):
         slider_names = [slider.field_name for slider in self.sliders]
         self.layer.setCustomProperty(WIDGET_SETTING_PREFIX % SLIDER_LIST_CONFIG_NAME, "###".join(slider_names))
-    
+
     def _add_slider(self, field_name):
         db = self.layer.dataProvider()
         i = db.fieldNameIndex(field_name)
         if i != -1:
           field = db.fields()[i]
-          if field.isNumeric():
+          if field.isNumeric() or (hasattr(field, 'isDateOrTime') and field.isDateOrTime()) or field.type() in [QtCore.QVariant.Date, QtCore.QVariant.DateTime]:
               field_max = self.layer.aggregate(QgsAggregateCalculator.Max, field.name())[0]
               field_min = self.layer.aggregate(QgsAggregateCalculator.Min, field.name())[0]
-                
+
+              is_date_or_time = False
+              # retrieve coercion setting if exists
+              coerced_setting = self.layer.customProperty(WIDGET_SETTING_PREFIX % ("COERCE_" + field_name), None)
+
+              if coerced_setting == "DATE":
+                  is_date_or_time = True
+              elif coerced_setting == "NUMBER":
+                  is_date_or_time = False
+              elif (hasattr(field, 'isDateOrTime') and field.isDateOrTime()) or field.type() in [QtCore.QVariant.Date, QtCore.QVariant.DateTime]:
+                  is_date_or_time = True
+
+              if is_date_or_time:
+                  # convert to timestamp (epoch seconds) for slider
+                  import datetime
+                  def _to_timestamp(val):
+                      if hasattr(val, 'toMSecsSinceEpoch'):
+                          return val.toMSecsSinceEpoch() / 1000.0
+                      elif type(val) is QDate:
+                          return QDateTime(val).toMSecsSinceEpoch() / 1000.0
+                      elif hasattr(val, 'toPython'):
+                          return val.toPython().timestamp()
+                      elif type(val) is datetime.date:
+                          return datetime.datetime(val.year, val.month, val.day).timestamp()
+                      elif type(val) is datetime.datetime:
+                          return val.timestamp()
+                      return val
+
+                  field_max = _to_timestamp(field_max)
+                  field_min = _to_timestamp(field_min)
+              elif coerced_setting is not None:
+                  # ensure field max/min are numbers in case they were natively dates but forced to numbers
+                  if hasattr(field_max, 'toMSecsSinceEpoch') or type(field_max) in [QtCore.QDate, QtCore.QDateTime] or hasattr(field_max, 'toPython'):
+                      import datetime
+                      def _to_timestamp(val):
+                          if hasattr(val, 'toMSecsSinceEpoch'):
+                              return val.toMSecsSinceEpoch() / 1000.0
+                          elif type(val) is QtCore.QDate:
+                              return QtCore.QDateTime(val).toMSecsSinceEpoch() / 1000.0
+                          elif hasattr(val, 'toPython'):
+                              return val.toPython().timestamp()
+                          elif type(val) is datetime.date:
+                              return datetime.datetime(val.year, val.month, val.day).timestamp()
+                          elif type(val) is datetime.datetime:
+                              return val.timestamp()
+                          return val
+                      field_max = _to_timestamp(field_max)
+                      field_min = _to_timestamp(field_min)
+
               try:
-                slider = RangeSlider(self, field_name, field_min, field_max)
+                slider = RangeSlider(self, field_name, field_min, field_max, is_date_or_time)
                 self.layout.addWidget(slider)
-                self.sliders.append(slider)        
+                self.sliders.append(slider)
               except ValueError as v:
-                QgsMessageLog.logMessage("Error for fieldname %s: %s" % (field_name, str(v)), 'Range Filter Plugin', level=Qgis.Warning)        
-                
+                QgsMessageLog.logMessage("Error for fieldname %s: %s" % (field_name, str(v)), 'Range Filter Plugin', level=Qgis.Warning)
+
               #self.layer.setCustomProperty(WIDGET_SETTING_PREFIX % field_name, "1")
-        
+
     def on_slider_changed(self, the_slider):
         text = " AND ".join([x for x in map(RangeSlider.getRangeFilter,  self.sliders) if x != ""])
         db = self.layer.dataProvider()
         db.setSubsetString(text)
-    
+
+    def on_coerce_slider(self, slider):
+        val = "DATE" if slider.is_date_or_time else "NUMBER"
+        self.layer.setCustomProperty(WIDGET_SETTING_PREFIX % ("COERCE_" + slider.field_name), val)
+
     def on_remove_slider(self, slider):
         self.sliders.remove(slider)
         self.layout.removeWidget(slider)
@@ -197,7 +301,7 @@ class DataLayerRangeFilterWidget(QWidget):
         # TODO: this doesn't cause the container for the widget to resize, which is what I was hoping for
         #self.parent().resize(self.parent().width(), self.parent().height() - 50)
         self.on_slider_changed(None)
-        
+
 
 class RangeFilterWidgetProvider(QgsLayerTreeEmbeddedWidgetProvider):
 
@@ -216,4 +320,3 @@ class RangeFilterWidgetProvider(QgsLayerTreeEmbeddedWidgetProvider):
     def supportsLayer(self, layer):
         # TODO: this is necc. but is it sufficient?
         return hasattr(layer.dataProvider(), "fields")
-        

--- a/test_range_slider.py
+++ b/test_range_slider.py
@@ -1,0 +1,164 @@
+import sys
+import datetime
+import os
+
+# Mock qgis modules so we can import the widget class
+class MockQgis:
+    class core:
+        Qgis = type('Qgis', (), {'Info': 1, 'Warning': 2})
+        class QgsMessageLog:
+            @staticmethod
+            def logMessage(msg, tag, level):
+                pass
+        QgsAggregateCalculator = type('QgsAggregateCalculator', (), {'Max': 1, 'Min': 2})
+        QgsMapLayer = type('QgsMapLayer', (), {})
+        QgsExpression = type('QgsExpression', (), {})
+        QgsExpressionContext = type('QgsExpressionContext', (), {})
+        QgsExpressionContextUtils = type('QgsExpressionContextUtils', (), {})
+    class PyQt:
+        class QtWidgets:
+            class QWidget:
+                def __init__(self):
+                    pass
+                def installEventFilter(self, *args):
+                    pass
+                def setToolTip(self, *args):
+                    pass
+                def setFixedWidth(self, *args):
+                    pass
+                def setLayout(self, *args):
+                    pass
+            class QVBoxLayout:
+                def addWidget(self, *args):
+                    pass
+            class QHBoxLayout:
+                def addWidget(self, *args):
+                    pass
+                def setContentsMargins(self, *args):
+                    pass
+            class QLabel(QWidget):
+                def __init__(self, text=""):
+                    super().__init__()
+            class QMenu(QWidget):
+                pass
+        class QtCore:
+            class QEvent:
+                ContextMenu = 1
+                DeferredDelete = 2
+            class QDate:
+                pass
+            class QDateTime:
+                @classmethod
+                def fromMSecsSinceEpoch(cls, msecs):
+                    import datetime
+                    dt = datetime.datetime.fromtimestamp(msecs / 1000.0)
+                    class MockQDateTime:
+                        def __init__(self, dt):
+                            self.dt = dt
+                        def toString(self, fmt):
+                            fmt = fmt.replace("yyyy", "%Y").replace("MM", "%m").replace("dd", "%d")
+                            fmt = fmt.replace("HH", "%H").replace("mm", "%M").replace("ss", "%S")
+                            return self.dt.strftime(fmt)
+                    return MockQDateTime(dt)
+            class QVariant:
+                Date = 14
+                DateTime = 16
+    class gui:
+        class QgsLayerTreeEmbeddedWidgetProvider:
+            def __init__(self):
+                pass
+        class QgsLayerTreeEmbeddedWidgetRegistry:
+            pass
+
+sys.modules['qgis'] = MockQgis
+sys.modules['qgis.core'] = MockQgis.core
+sys.modules['qgis.PyQt'] = MockQgis.PyQt
+sys.modules['qgis.PyQt.QtWidgets'] = MockQgis.PyQt.QtWidgets
+sys.modules['qgis.PyQt.QtCore'] = MockQgis.PyQt.QtCore
+sys.modules['qgis.gui'] = MockQgis.gui
+sys.modules['PyQt5'] = type('PyQt5', (), {'QtCore': MockQgis.PyQt.QtCore})
+sys.modules['PyQt5.QtCore'] = MockQgis.PyQt.QtCore
+
+# Mock qrangeslider
+class MockQRangeSlider(MockQgis.PyQt.QtWidgets.QWidget):
+    def __init__(self):
+        super().__init__()
+        class Signal:
+            def connect(self, fn):
+                pass
+        self.startValueChanged = Signal()
+        self.endValueChanged = Signal()
+    def setDrawValues(self, *args):
+        pass
+    def setFixedHeight(self, *args):
+        pass
+    def setEnabled(self, *args):
+        pass
+    def max(self):
+        return 100
+    def start(self):
+        return 0
+    def end(self):
+        return 100
+
+sys.modules['qrangeslider'] = type('qrangeslider', (), {'QRangeSlider': MockQRangeSlider})
+
+# modify import locally to allow importing
+with open("data_layer_range_filter_widget.py", "r") as f:
+    content = f.read()
+content = content.replace("from .qrangeslider import QRangeSlider", "from qrangeslider import QRangeSlider")
+with open("data_layer_range_filter_widget_test.py", "w") as f:
+    f.write(content)
+
+from data_layer_range_filter_widget_test import RangeSlider
+
+def test_date_range():
+    print("Running Test 1: Date Range")
+    fmin = datetime.datetime(2021, 1, 1).timestamp()
+    fmax = datetime.datetime(2021, 1, 5).timestamp() # 4 days
+    slider = RangeSlider(None, "date_field", fmin, fmax, is_date_or_time=True)
+    slider.slider.start = lambda: 0
+    slider.slider.end = lambda: 50 # middle
+
+    assert slider.pretty(0) == "2021-01-01 00:00", f"Got: {slider.pretty(0)}"
+    assert slider.getQueryValue(0) == "'2021-01-01 00:00:00'"
+
+    slider._dirty = True
+    assert slider.getRangeFilter() == '"date_field" >= \'2021-01-01 00:00:00\' AND "date_field" <= \'2021-01-03 00:00:00\''
+    print("Test 1 passed.")
+
+def test_time_range():
+    print("Running Test 2: Time Range (< 1 day)")
+    fmin2 = datetime.datetime(2021, 1, 1, 12, 0).timestamp()
+    fmax2 = datetime.datetime(2021, 1, 1, 18, 0).timestamp() # 6 hours
+    slider2 = RangeSlider(None, "date_field_2", fmin2, fmax2, is_date_or_time=True)
+    assert slider2.pretty(0) == "12:00:00", f"Got: {slider2.pretty(0)}"
+    print("Test 2 passed.")
+
+if __name__ == '__main__':
+    test_date_range()
+    test_time_range()
+
+    # Cleanup
+    if os.path.exists("data_layer_range_filter_widget_test.py"):
+        os.remove("data_layer_range_filter_widget_test.py")
+
+def test_coerce():
+    print("Running Test 3: Type Coercion Menu")
+    # To test coercion logic, we simulate an event filter execution
+    fmin = datetime.datetime(2021, 1, 1).timestamp()
+    fmax = datetime.datetime(2021, 1, 5).timestamp() # 4 days
+    class MockParent:
+        def on_coerce_slider(self, s):
+            pass
+    slider = RangeSlider(None, "date_field", fmin, fmax, is_date_or_time=True)
+    slider.parent = MockParent()
+
+    # Try coercing to NUMBER
+    slider.is_date_or_time = not slider.is_date_or_time
+    # pretty should now just format as number
+    assert slider.pretty(100) != "2021-01-05 00:00"
+    print("Test 3 passed.")
+
+if __name__ == '__main__':
+    test_coerce()


### PR DESCRIPTION
Implemented support for Date and Date/Time fields range filtering in QGIS plugins. Added formatting for pretty display based on slider duration. Allowed users to coerce types via right-click for incorrectly identified metadata, saving states across sessions natively. Added tests simulating QGIS core environments.

---
*PR created automatically by Jules for task [5821490571654155345](https://jules.google.com/task/5821490571654155345) started by @orcaomar*