### PR TITLE
Fix embedded widget sizing when layout changes

### DIFF
--- a/data_layer_range_filter_widget.py
+++ b/data_layer_range_filter_widget.py
@@ -489,6 +489,8 @@ class DataLayerRangeFilterWidget(QWidget):
                 self._add_filter(field.name())
         self._save_sliders()
         self.on_slider_changed(None)
+        self.adjustSize()
+        self.updateGeometry()
 
     def eventFilter(self, source, event):
       # TODO: This event is emitted when the legend widget is removed. I am not sure if this is the right way to handle widget removeal
@@ -632,9 +634,9 @@ class DataLayerRangeFilterWidget(QWidget):
         self.layout.removeWidget(slider)
         self._save_sliders()
         slider.deleteLater()
-        # TODO: this doesn't cause the container for the widget to resize, which is what I was hoping for
-        #self.parent().resize(self.parent().width(), self.parent().height() - 50)
         self.on_slider_changed(None)
+        self.adjustSize()
+        self.updateGeometry()
 
 
 class RangeFilterWidgetProvider(QgsLayerTreeEmbeddedWidgetProvider):


### PR DESCRIPTION
The embedded legend widget was leaving blank space or overflowing its content boundaries when the layout was switched between Classic and Spacious UI modes. This happened because the parent layer tree was not notified of the widget's new size hint. This commit adds `adjustSize()` and `updateGeometry()` when the widgets change to accurately force a size refresh.

---
*PR created automatically by Jules for task [1115247482365318800](https://jules.google.com/task/1115247482365318800) started by @orcaomar*